### PR TITLE
fix 'jumping between dirs with different venvs does not trigger reactivation' issue

### DIFF
--- a/functions/dirvenv.fish
+++ b/functions/dirvenv.fish
@@ -26,16 +26,23 @@ end
 function dirvenv -d "Toggles the virtualenv detected by `dirvenv` on and off"
     set -f venv (find_venv)
     set -f activated (string join / (path normalize (string length -q "$TMPDIR" && echo "$TMPDIR" || echo /tmp) ) ".direnv")
+    
     if set -q VIRTUAL_ENV
-        if test -z "$venv" && test -e $activated
-            if string match -q "$fish_pid:$VIRTUAL_ENV" (cat "$activated")
-                deactivate
-                cat "$activated" | string match -v "$fish_pid:$VIRTUAL_ENV" >$activated
+        if test -z "$venv" || test "$venv/bin/activate.fish" != "$VIRTUAL_ENV/bin/activate.fish"
+            if test -e $activated
+                if string match -q "$fish_pid:$VIRTUAL_ENV" (cat "$activated")
+                    deactivate
+                    cat "$activated" | string match -v "$fish_pid:$VIRTUAL_ENV" >$activated
+                end
             end
+        else
+            return 0
         end
-    else
+    end
+    
+    if test -n "$venv"
         set -l activate "$venv/bin/activate.fish"
-        if test -n "$venv" && test -f "$activate"
+        if test -f "$activate"
             source "$activate"
             echo "$fish_pid:$VIRTUAL_ENV" >>"$activated"
         end


### PR DESCRIPTION
Now with the fix:

```
~ $ which python
/usr/bin/python
~ $ z rele
~/workspace/ai/release-bot on 🌱 main [🖊️🤷 🗸] 🐍 $  which python
/home/kjozsa/workspace/ai/release-bot/.venv/bin/python
~/workspace/ai/release-bot on 🌱 main [🖊️🤷 🗸] 🐍 $  z git-mcp
~/w/ai/mcp/git-mcp on 🌱 main [🖊️🤷 🗸] 🐍 $  which python
/home/kjozsa/workspace/ai/mcp/git-mcp/.venv/bin/python
~/w/ai/mcp/git-mcp on 🌱 main [🖊️🤷 🗸] 🐍 $  cd
~ $ which python
/usr/bin/python
~ $ 
```

Fixes #1 